### PR TITLE
fix(ci): resolve docs workflow warnings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Build job
   build:
@@ -32,6 +35,8 @@ jobs:
         run: pipx install poetry
       - name: Setup Python
         uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
       - name: Install dependencies
         run: poetry install --with docs
       - name: Build with Sphinx

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
+          python-version: "3.12"
       - name: Install dependencies
         run: poetry install --with docs
       - name: Build with Sphinx


### PR DESCRIPTION
## Summary
- Add explicit `python-version: "3.x"` to `setup-python` step to eliminate the missing version warning
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to suppress Node.js 20 deprecation warnings for `configure-pages@v5`, `upload-pages-artifact@v4`, and `deploy-pages@v4`

## Test plan
- [x] Trigger docs workflow manually and verify no warnings