### PR TITLE
Release/2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-03-25
+
+### Fixed
+- Fixed case-insensitive file extension handling in `Instance.from_path()`: files with uppercase extensions (`.XBRL`, `.XML`, `.ZIP`) are now processed correctly (#109).
+
 ## [2.0.0] - 2026-03-17
 
 ### Added
@@ -166,7 +171,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial pre-release version
 
-[Unreleased]: https://github.com/Meaningful-Data/xbridge/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/Meaningful-Data/xbridge/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/Meaningful-Data/xbridge/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Meaningful-Data/xbridge/compare/v1.5.2...v2.0.0
 [1.5.2]: https://github.com/Meaningful-Data/xbridge/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/Meaningful-Data/xbridge/compare/v1.5.0...v1.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eba-xbridge"
-version = "2.0.0"
+version = "2.0.1"
 description = "XBRL-XML to XBRL-CSV converter for EBA Taxonomy (version 4.2)"
 license = 'Apache 2.0'
 readme = "README.rst"

--- a/src/xbridge/__init__.py
+++ b/src/xbridge/__init__.py
@@ -2,4 +2,4 @@
 Init file for eba-xbridge library
 """
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/src/xbridge/instance.py
+++ b/src/xbridge/instance.py
@@ -152,9 +152,10 @@ class Instance:
     def from_path(cls, path: Union[str, Path]) -> Instance:
         path = Path(path)
 
-        if path.suffix in [".xml", ".xbrl"]:
+        suffix = path.suffix.lower()
+        if suffix in [".xml", ".xbrl"]:
             return XmlInstance(path)
-        elif path.suffix == ".zip":
+        elif suffix == ".zip":
             return CsvInstance(path)
         else:
             raise ValueError(f"Unsupported file extension: {path.suffix}")


### PR DESCRIPTION
## Description                                                                                                                          
                                         
  Fix case-insensitive file extension handling in `Instance.from_path()`, so that files with uppercase extensions (`.XBRL`, `.XML`,       
  `.ZIP`) are processed correctly. Bump version to 2.0.1.                                                                                 
                                                                                                                                          
  ## Type of Change                                         

  - [x] Bug fix (non-breaking change which fixes an issue)                                                                                
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)                                  
  - [ ] Documentation update                                
  - [ ] Performance improvement
  - [ ] Code refactoring                                                                                                                  
  - [ ] Dependency update
  - [ ] Other (please describe):                                                                                                          
                                                            
  ## Related Issues

  Closes #109

  ## Changes Made

  - Normalized file suffix to lowercase in `Instance.from_path()` before comparing against supported extensions, consistent with the      
  approach already used in the validation module.
  - Bumped version to 2.0.1 in `pyproject.toml` and `src/xbridge/__init__.py`.                                                            
  - Added changelog entry for 2.0.1.                        

  ## Testing

  ### Tests Added

  - [ ] Unit tests                                                                                                                        
  - [ ] Integration tests
  - [x] Test coverage maintained or improved                                                                                              
                                                            
  ### Testing Performed

  ```bash
  poetry run pytest tests/

  Test results:
  - All existing tests pass (950 passed)
  - New tests pass                      
  - Manual testing performed

  Documentation                                                                                                                           
   
  - Updated docstrings                                                                                                                    
  - Updated README.md                                       
  - Updated documentation in docs/
  - Updated CHANGELOG.md (added entry under "Unreleased")
  - No documentation needed for this change

  Code Quality                                                                                                                            
   
  - Code follows the project's style guidelines (Ruff)                                                                                    
  - Ran ruff check and ruff format                          
  - Ran mypy type checking
  - Self-review of code completed
  - Comments added for complex/non-obvious code
  - No new warnings generated                                                                                                             
   
  Breaking Changes                                                                                                                        
                                                            
  N/A

  Screenshots (if applicable)

  N/A

  Checklist

  - My code follows the project's code style
  - I have performed a self-review of my code
  - I have commented my code, particularly in hard-to-understand areas                                                                    
  - I have made corresponding changes to the documentation
  - My changes generate no new warnings                                                                                                   
  - I have added tests that prove my fix is effective or that my feature works
  - New and existing unit tests pass locally with my changes                                                                              
  - Any dependent changes have been merged and published
  - I have updated the CHANGELOG.md                                                                                                       
                                                            
  Additional Notes

  The validation module (_engine.py, _context.py) already used .suffix.lower() for extension checks. This change brings                   
  Instance.from_path() in line with that pattern.
                                                                                                                                          
  Reviewer Notes                                            

  Areas to focus on:
  - The one-line change in src/xbridge/instance.py:155
                                                      