### PR TITLE
Add Ubuntu 24.04 APT CI workflow and lower numpy floor to 1.26.4

### DIFF
--- a/.github/workflows/ubuntu_test_24_04.yml
+++ b/.github/workflows/ubuntu_test_24_04.yml
@@ -1,0 +1,44 @@
+name: Ubuntu 24.04 APT Tests
+
+on:
+  pull_request:
+    branches: ["main", "dev"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install runtime dependencies from APT
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            python3-pip \
+            python3-pandas \
+            python3-lxml
+        # python3-pandas pulls in python3-numpy automatically
+
+      - name: Install pytest from pip
+        run: pip install --break-system-packages pytest
+
+      - name: Report installed versions
+        run: |
+          python3 --version
+          python3 -c "import pandas, lxml, numpy; print('pandas', pandas.__version__); print('numpy', numpy.__version__); print('lxml', lxml.__version__)"
+          pytest --version
+
+      - name: Install xbridge without dependencies
+        run: pip install --no-dependencies --break-system-packages .
+
+      - name: Run tests
+        run: pytest --strict-markers

--- a/.github/workflows/ubuntu_test_24_04.yml
+++ b/.github/workflows/ubuntu_test_24_04.yml
@@ -19,17 +19,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install runtime dependencies from APT
+      - name: Install Python dependencies from APT
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             python3-pip \
             python3-pandas \
-            python3-lxml
+            python3-lxml \
+            python3-pytest
         # python3-pandas pulls in python3-numpy automatically
-
-      - name: Install pytest from pip
-        run: pip install --break-system-packages pytest
 
       - name: Report installed versions
         run: |


### PR DESCRIPTION
## What

Adds `.github/workflows/ubuntu_test_24_04.yml` — a CI workflow that runs on `ubuntu-24.04` and installs
xbridge's Python dependencies from **APT** (`python3-*` packages) instead of PyPI, then runs the test suite.

It also lowers the minimum `numpy` (Python < 3.13) from `2.0.2` to **`1.26.4`** to match the version
Ubuntu 24.04 ships in APT.

## Why

The existing `testing.yml` only validates xbridge against **PyPI wheels** (via Poetry). This workflow
checks the package against the **distro-provided** versions a Debian/Ubuntu user — or a future system
package — would actually receive.

## How it works

- Dependencies from APT: `python3-pandas` (pulls in `python3-numpy` transitively), `python3-lxml`, and `python3-pytest`.
- xbridge installed with `pip install --no-dependencies --break-system-packages .`, so the suite runs against the APT-provided deps.
- A "Report installed versions" step prints the actual versions to the logs.

## Result

The APT run passes against the distro versions it installs:

| | version |
|---|---|
| Python | 3.12.3 |
| pandas | 2.1.4 |
| numpy | 1.26.4 |
| lxml | 5.2.1 |
| pytest | 7.4.4 |

Since the suite passes on numpy 1.26.4, the `numpy>=2.0.2` floor (Python < 3.13) is lowered to `>=1.26.4`
to match what APT provides and reflect the version we actually test against. Locked versions are unchanged
(the `<2.1` constraint still resolves to numpy 2.0.x on PyPI); only `poetry.lock`'s content-hash is refreshed.

## Notes

- Opened as **draft** until reviewed.
- Refs #114.
